### PR TITLE
add identifier to AMD module definition

### DIFF
--- a/seedrandom.js
+++ b/seedrandom.js
@@ -319,7 +319,7 @@ mixkey(math[rngname](), pool);
 if (module && module.exports) {
   module.exports = impl;
 } else if (define && define.amd) {
-  define(function() { return impl; });
+  define('seedrandom', function() { return impl; });
 }
 
 // End anonymous scope, and pass initial values.

--- a/test/require.html
+++ b/test/require.html
@@ -1,12 +1,12 @@
-<script src="lib/require.js">
-</script>
+<script src="lib/require.js"></script>
+<script src="../seedrandom.min.js"></script>
 <script src="lib/qunit.js"></script>
 <script>
 module("Require.js Test");
 
 asyncTest("Check that we can load as an AMD", function() {
 
-require(["../seedrandom.min"], function(seedrandom) {
+require(["seedrandom"], function(seedrandom) {
   document.write("<p>Seeded random created using module:<br>");
   var check = [];
   var prng = seedrandom('predictable.');


### PR DESCRIPTION
If the module definition lack id, the only way to require seedrandom is by path.

By adding the id, it is possible to load seedrandom with script tag and use `require('seedrandom')` for require.
