### PR TITLE
Update global detection to work with strict mode builds.

### DIFF
--- a/seedrandom.js
+++ b/seedrandom.js
@@ -26,7 +26,10 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 // The following constants are related to IEEE 754 limits.
 //
-var global = this,
+
+// Detect the global object, even if operating in strict mode.
+// http://stackoverflow.com/a/14387057/265298
+var global = (0, eval)('this'),
     width = 256,        // each RC4 output is 0 <= x < 256
     chunks = 6,         // at least six RC4 outputs for each double
     digits = 52,        // there are 52 significant digits in a double

--- a/test/browserified.js
+++ b/test/browserified.js
@@ -31,7 +31,10 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 // The following constants are related to IEEE 754 limits.
 //
-var global = this,
+
+// Detect the global object, even if operating in strict mode.
+// http://stackoverflow.com/a/14387057/265298
+var global = (0, eval)('this'),
     width = 256,        // each RC4 output is 0 <= x < 256
     chunks = 6,         // at least six RC4 outputs for each double
     digits = 52,        // there are 52 significant digits in a double


### PR DESCRIPTION
The logic for grabbing the global object causes issues when
seedrandom.js is included in minified browser payloads that explicitly
use strict mode globally. Update this technique to use the function
constructor which does not inherit its strictness from the caller.