### PR TITLE
Add unpkg and jsdelivr fields to point CDNs to entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "3.0.1",
   "description": "Seeded random number generator for Javascript.",
   "main": "index.js",
+  "jsdelivr": "seedrandom.min.js",
+  "unpkg": "seedrandom.min.js",
   "keywords": [
     "seed",
     "random",


### PR DESCRIPTION
Hi there!

This PR adds [unpkg](https://unpkg.com/) and [jsdelivr](https://www.jsdelivr.com/) fields to the package.json for seedrandom, so that people who use browser require libraries (like d3-require or requirejs) with those CDNs immediately get the correct UMD build instead of the CommonJS `index.js` file.