### PR TITLE
Avoid using eval() to get global object.

### DIFF
--- a/seedrandom.js
+++ b/seedrandom.js
@@ -22,15 +22,12 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 */
 
-(function (pool, math) {
+(function (global, pool, math) {
 //
 // The following constants are related to IEEE 754 limits.
 //
 
-// Detect the global object, even if operating in strict mode.
-// http://stackoverflow.com/a/14387057/265298
-var global = (0, eval)('this'),
-    width = 256,        // each RC4 output is 0 <= x < 256
+var width = 256,        // each RC4 output is 0 <= x < 256
     chunks = 6,         // at least six RC4 outputs for each double
     digits = 52,        // there are 52 significant digits in a double
     rngname = 'random', // rngname: name for Math.random and Math.seedrandom
@@ -248,6 +245,9 @@ if ((typeof module) == 'object' && module.exports) {
 
 // End anonymous scope, and pass initial values.
 })(
+  // global: `self` in browsers (including strict mode and web workers),
+  // otherwise `this` in Node and other environments
+  (typeof self !== 'undefined') ? self : this,
   [],     // pool: entropy pool starts empty
   Math    // math: package containing random, pow, and seedrandom
 );


### PR DESCRIPTION
Following up from #64, this PR avoids using `eval()` to get the global object, which causes this package to be unusable if a server has set Content-Security Policy (CSP) protocols. I use the [Universal Module Definition (UMD)](https://github.com/umdjs/umd/blob/master/templates/commonjsStrictGlobal.js#L32) pattern, bringing back the way we inject the global object into the function via its arguments.

I should also note that there is [a stage-3 ECMAScript proposal for `globalThis`](https://github.com/tc39/proposal-global), which is meant to address exactly this problem. Some browsers and environments have [begun to implement `globalThis`](https://kangax.github.io/compat-table/esnext/#test-globalThis) but even if we were to use it now, we would still need a fallback to `self` or `this`. Let me know if you would like to use `globalThis` now, but I can also understand waiting for the proposal to be finalized first.

Let me know if there's anything else I should do to finish this PR! Thanks!
