### PR TITLE
package.json: specify the files to include

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "version": "3.0.5",
   "description": "Seeded random number generator for Javascript.",
   "main": "index.js",
+  "files": [
+    "lib/*.js",
+    "index.js",
+    "seedrandom.js",
+    "seedrandom.min.js"
+  ],
   "jsdelivr": "seedrandom.min.js",
   "unpkg": "seedrandom.min.js",
   "keywords": [


### PR DESCRIPTION
Currently the npm package includes many useless files, like .nyc_output, coverage, tests and more.

With this patch:

```
C:\Users\xmr\Desktop\seedrandom>npm pack --dry
npm notice
npm notice package: seedrandom@3.0.5
npm notice === Tarball Contents ===
npm notice 12.2kB README.md
npm notice 2.2kB  index.js
npm notice 3.4kB  lib/alea.js
npm notice 970B   lib/alea.min.js
npm notice 256B   lib/crypto.js
npm notice 2.6kB  lib/tychei.js
npm notice 861B   lib/tychei.min.js
npm notice 1.8kB  lib/xor128.js
npm notice 737B   lib/xor128.min.js
npm notice 4.7kB  lib/xor4096.js
npm notice 1.1kB  lib/xor4096.min.js
npm notice 2.5kB  lib/xorshift7.js
npm notice 969B   lib/xorshift7.min.js
npm notice 2.0kB  lib/xorwow.js
npm notice 825B   lib/xorwow.min.js
npm notice 1.6kB  package.json
npm notice 8.9kB  seedrandom.js
npm notice 1.6kB  seedrandom.min.js
npm notice === Tarball Details ===
npm notice name:          seedrandom
npm notice version:       3.0.5
npm notice filename:      seedrandom-3.0.5.tgz
npm notice package size:  16.3 kB
npm notice unpacked size: 49.2 kB
npm notice shasum:        04d702b74e24e0f4f1d73d5bb1f81f450e6e8045
npm notice integrity:     sha512-LSGCFcLwaANo0[...]vcKPQlVdBFwcA==
npm notice total files:   18
npm notice
seedrandom-3.0.5.tgz
```

/CC @davidbau to merge and make a new patch version :)